### PR TITLE
Add support for copying files

### DIFF
--- a/examples/test1.rs
+++ b/examples/test1.rs
@@ -1,6 +1,7 @@
 extern crate tsunami;
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::time;
 use tsunami::{Machine, MachineSetup, TsunamiBuilder};
 
@@ -11,9 +12,12 @@ fn main() {
         "server",
         1,
         MachineSetup::new("c5.xlarge", "ami-e18aa89b", |ssh| {
-            ssh.cmd("cat /etc/hostname").map(|out| {
+            ssh.upload(Path::new("/etc/hostname"), Path::new("local-hostname"))?;
+            ssh.cmd("cat local-hostname").map(|out| {
                 println!("{}", out);
-            })
+            })?;
+
+            ssh.download(Path::new("/etc/hostname"), Path::new("server-hostname"))
         }),
     );
     b.add_set(

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,11 +1,20 @@
 use failure::Error;
+use failure::Fail;
 use failure::ResultExt;
 use slog;
 use ssh2;
+use std::fs::File;
+use std::io;
 use std::net::{SocketAddr, TcpStream};
 use std::path::Path;
 use std::thread;
 use std::time::{Duration, Instant};
+
+#[derive(Debug, Fail)]
+enum SshError {
+    #[fail(display = "error transferring file {}: {}", file, msg)]
+    FileTransferFailure { file: String, msg: String },
+}
 
 /// An established SSH session.
 ///
@@ -115,6 +124,123 @@ impl Session {
     /// Issue the given command and return the command's standard output.
     pub fn cmd(&self, cmd: &str) -> Result<String, Error> {
         Ok(String::from_utf8(self.cmd_raw(cmd)?)?)
+    }
+
+    /// Copy a file from the local machine to the remote host.
+    ///
+    /// Both remote and local paths can be absolute or relative.
+    ///
+    /// ```rust,no_run
+    /// # use tsunami::Session;
+    /// # use failure::Error;
+    /// # fn upload_artifact(ssh: Session) -> Result<(), Error> {
+    ///     use std::path::Path;
+    ///     ssh.upload(
+    ///         Path::new("build/output.tar.gz"), // on the local machine
+    ///         Path::new("/srv/output.tar.gz"), // on the remote machine
+    ///     )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn upload(&self, local_src: &Path, remote_dst: &Path) -> Result<(), Error> {
+        let sftp = self.ssh.sftp().map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to create ssh channel while uploading file '{}'",
+                local_src.display()
+            ))
+        })?;
+        let mut dst_file = sftp.create(&remote_dst).map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to create file '{}' on remote host",
+                remote_dst.display()
+            ))
+        })?;
+
+        let mut src_file = File::open(&local_src).map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to open file '{}' on local machine",
+                local_src.display()
+            ))
+        })?;
+
+        let copied = io::copy(&mut src_file, &mut dst_file)
+            .map_err(Error::from)
+            .map_err(|e| {
+                e.context(format!(
+                    "failed to upload file '{}' to remote host",
+                    local_src.display()
+                ))
+            })?;
+
+        let expected = src_file.metadata()?.len();
+        if copied < expected {
+            Err(SshError::FileTransferFailure {
+                file: local_src.display().to_string(),
+                msg: format!("only copied {}/{} bytes", copied, expected),
+            })?
+        }
+
+        Ok(())
+    }
+
+    /// Copy a file from the remote host to the local machine.
+    ///
+    /// Both remote and local paths can be absolute or relative.
+    ///
+    /// ```rust,no_run
+    /// # use tsunami::Session;
+    /// # use failure::Error;
+    /// # fn download_hostname(ssh: Session) -> Result<(), Error> {
+    ///     use std::path::Path;
+    ///     ssh.download(
+    ///         Path::new("/etc/hostname"), // on the remote machine
+    ///         Path::new("remote-hostname"), // on the local machine
+    ///     )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn download(&self, remote_src: &Path, local_dst: &Path) -> Result<(), Error> {
+        let sftp = self.ssh.sftp().map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to create ssh channel while downloading file '{}'",
+                remote_src.display()
+            ))
+        })?;
+        let mut src_file = sftp.open(&remote_src).map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to open file '{}' on remote host",
+                remote_src.display()
+            ))
+        })?;
+
+        let mut dst_file = File::create(&local_dst).map_err(Error::from).map_err(|e| {
+            e.context(format!(
+                "failed to create file '{}' on local machine",
+                local_dst.display()
+            ))
+        })?;
+
+        let copied = io::copy(&mut src_file, &mut dst_file)
+            .map_err(Error::from)
+            .map_err(|e| {
+                e.context(format!(
+                    "failed to download file '{}' from remote host",
+                    remote_src.display()
+                ))
+            })?;
+
+        // `stat().size` can be None. A little odd but not worth failing if
+        // everything else seemed to succeed.
+        if let Some(expected) = src_file.stat()?.size {
+            if copied < expected {
+                Err(SshError::FileTransferFailure {
+                    file: remote_src.display().to_string(),
+                    msg: format!("only copied {}/{} bytes", copied, expected),
+                })?
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -11,9 +11,10 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Fail)]
-enum SshError {
-    #[fail(display = "error transferring file {}: {}", file, msg)]
-    FileTransferFailure { file: String, msg: String },
+#[fail(display = "error transferring file {}: {}", file, msg)]
+struct FileTransferFailure {
+    file: String,
+    msg: String,
 }
 
 /// An established SSH session.
@@ -174,7 +175,7 @@ impl Session {
 
         let expected = src_file.metadata()?.len();
         if copied < expected {
-            Err(SshError::FileTransferFailure {
+            Err(FileTransferFailure {
                 file: local_src.display().to_string(),
                 msg: format!("only copied {}/{} bytes", copied, expected),
             })?
@@ -233,7 +234,7 @@ impl Session {
         // everything else seemed to succeed.
         if let Some(expected) = src_file.stat()?.size {
             if copied < expected {
-                Err(SshError::FileTransferFailure {
+                Err(FileTransferFailure {
                     file: remote_src.display().to_string(),
                     msg: format!("only copied {}/{} bytes", copied, expected),
                 })?


### PR DESCRIPTION
Hi Jon! Not sure if you know me, I sit a floor down from you (err...not lately,
but you you know what I mean). Thanks for the library, it's been useful.

I've added, in the style of `scp(1)`, support for uploading/downloading files:

```rust
MachineSetup::new("c5.xlarge", "ami-e18aa89b", |ssh| {
    ssh.upload(
        Path::new("/path/on/local/machine.rar"),
        Path::new("dest/on/remote/machine.rar")
    )?;
    ssh.download(
        Path::new("remote-machine/business.xls"),
        Path::new("/tmp/business.xls")
    )?;
    Ok(())
});
```

I've verified that it works in a quick example, and I'm planning to use it for
some experiments very soon (copying a source tarball up, then building it, then
copying the binaries back down). I'll let you know if that doesn't go well.


I'm almost tempted to implement this as `Session.open(&Path) -> Result<ssh2::File, _>` to enable:

``` rust
let remote_src = ssh.open(Path::new("file"))?;
let remote_dst = ssh.open(Path::new("file"))?;
std::io:copy(remote_src, remote_dst)?;
```

but this oughta suffice for most use cases.