### PR TITLE
Retry loop to delete aws security groups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ ubuntu-ami = { version = "0.1", optional = true }
 [dev-dependencies]
 rusoto_sts = "0.43.0"
 tokio = { version = "0.2.0", features = ["rt-core", "macros"] }
+tracing-subscriber = "0.2"
 
 [[example]]
 name = "launch"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@
 //! [`tracing_subscriber::fmt`](https://docs.rs/tracing-subscriber/0.2/tracing_subscriber/fmt/index.html),
 //! which you can instantiate (after adding it to your Cargo.toml) with:
 //!
-//! ```rust,ignore
+//! ```rust
 //! tracing_subscriber::fmt::init();
 //! ```
 //!

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -1345,8 +1345,10 @@ impl RegionLauncher {
                                 tracing::trace!("instances not yet shut down -- retrying");
                                 tokio::time::delay_for(tokio::time::Duration::from_secs(5)).await;
                             } else {
-                                Err(eyre!(err.to_string()))
-                                    .wrap_err("failed to clean up temporary security group")?;
+                                Err(Report::new(RusotoError::<
+                                    rusoto_ec2::DeleteSecurityGroupError,
+                                >::Unknown(r)))
+                                .wrap_err("failed to clean up temporary security group")?;
                                 unreachable!();
                             }
                         }

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -1313,7 +1313,7 @@ impl RegionLauncher {
                     //    block will get skipped, so sg will get cleaned up below.
                     // 2. there were instances, but we couldn't terminate them. Then, the sg will
                     //    still be attached to them, so there's no point trying to delete it.
-                    Err(e).context("failed to terminate tsunami instances")?;
+                    Err(e).wrap_err("failed to terminate tsunami instances")?;
                     unreachable!();
                 }
             }
@@ -1323,7 +1323,7 @@ impl RegionLauncher {
         if !self.security_group_id.trim().is_empty() {
             let group_span =
                 tracing::trace_span!("removing security group", id = %self.security_group_id);
-            let r = async {
+            async {
                 tracing::trace!("removing security group.");
                 // clean up security groups and keys
                 let start = tokio::time::Instant::now();
@@ -1362,9 +1362,7 @@ impl RegionLauncher {
                 Ok::<_, Report>(())
             }
             .instrument(group_span)
-            .await;
-
-            r?;
+            .await?;
         }
 
         Ok(())

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -1405,6 +1405,7 @@ mod test {
     #[ignore]
     fn make_machine_and_ssh_setupfn() {
         use crate::providers::Launcher;
+        tracing_subscriber::fmt::init();
         let mut rt = tokio::runtime::Runtime::new().unwrap();
         let mut l = super::Launcher::default();
         // make the defined-duration instances expire after 1 hour
@@ -1429,8 +1430,11 @@ mod test {
         let ec2 = RegionLauncher::connect(region, super::AvailabilityZoneSpec::Any, provider)?;
         rt.block_on(async {
             let mut ec2 = ec2.make_ssh_key().await?;
-            println!("==> key name: {}", ec2.ssh_key_name);
-            println!("==> key path: {:?}", ec2.private_key_path);
+            tracing::debug!(
+                name = %ec2.ssh_key_name,
+                path = %ec2.private_key_path.as_ref().unwrap().path().display(),
+                "made key"
+            );
             assert!(!ec2.ssh_key_name.is_empty());
             assert!(ec2.private_key_path.as_ref().unwrap().path().exists());
 


### PR DESCRIPTION
In my tests, it seems to take about 15 seconds of retrying, so the retry loop is 5 sec long. We could do fancier things like exponential backoff, but this is good enough for now I think. 

Fixes #2

```
May 21 11:37:30.811 TRACE terminate_all{self=Launcher { max_instance_duration_hours: 1, use_open_ports: false, regions: {"us-east-1": RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "s
g-0cf3db4d6b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my
machine", setup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amaz
onaws.com", public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }} }}:region{region=us-east-1}:terminate_all{self=RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "sg-0cf3db4d6
b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my machine", s
etup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amazonaws.com",
 public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }}:security_group{id=sg-0cf3db4d6b3582264}: tsunami::providers::aws: removing security group.
May 21 11:37:31.254 TRACE terminate_all{self=Launcher { max_instance_duration_hours: 1, use_open_ports: false, regions: {"us-east-1": RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "s
g-0cf3db4d6b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my
machine", setup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amaz
onaws.com", public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }} }}:region{region=us-east-1}:terminate_all{self=RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "sg-0cf3db4d6
b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my machine", s
etup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amazonaws.com",
 public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }}:security_group{id=sg-0cf3db4d6b3582264}: tsunami::providers::aws: failed to clean up temporary security group: Request ID: None Body: <?xml version=
"1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>DependencyViolation</Code><Message>resource sg-0cf3db4d6b3582264 has a dependent object</Message></Error></Errors><RequestID>59046c08-1c08-4a84-a5c5-548cbbb259cc</RequestID></Respons
e>. retrying.
May 21 11:37:36.873 TRACE terminate_all{self=Launcher { max_instance_duration_hours: 1, use_open_ports: false, regions: {"us-east-1": RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "s
g-0cf3db4d6b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my
machine", setup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amaz
onaws.com", public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }} }}:region{region=us-east-1}:terminate_all{self=RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "sg-0cf3db4d6
b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my machine", s
etup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amazonaws.com",
 public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }}:security_group{id=sg-0cf3db4d6b3582264}: tsunami::providers::aws: failed to clean up temporary security group: Request ID: None Body: <?xml version=
"1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>DependencyViolation</Code><Message>resource sg-0cf3db4d6b3582264 has a dependent object</Message></Error></Errors><RequestID>cebaa992-a8ae-4ad7-a836-95d24393fecd</RequestID></Respons
e>. retrying.
May 21 11:37:42.397 TRACE terminate_all{self=Launcher { max_instance_duration_hours: 1, use_open_ports: false, regions: {"us-east-1": RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "s
g-0cf3db4d6b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my
machine", setup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amaz
onaws.com", public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }} }}:region{region=us-east-1}:terminate_all{self=RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "sg-0cf3db4d6
b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my machine", s
etup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amazonaws.com",
 public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }}:security_group{id=sg-0cf3db4d6b3582264}: tsunami::providers::aws: failed to clean up temporary security group: Request ID: None Body: <?xml version=
"1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>DependencyViolation</Code><Message>resource sg-0cf3db4d6b3582264 has a dependent object</Message></Error></Errors><RequestID>483036cc-69a0-43b8-b3f1-9b3a3c67a965</RequestID></Respons
e>. retrying.
May 21 11:37:47.884 TRACE terminate_all{self=Launcher { max_instance_duration_hours: 1, use_open_ports: false, regions: {"us-east-1": RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "s
g-0cf3db4d6b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my
machine", setup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amaz
onaws.com", public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }} }}:region{region=us-east-1}:terminate_all{self=RegionLauncher { region: UsEast1, availability_zone: Any, security_group_id: "sg-0cf3db4d6
b3582264", ssh_key_name: "tsunami_key_LgHBYrBD5A", private_key_path: Some(NamedTempFile("/tmp/.tmpRMFqkL")), outstanding_spot_request_ids: {}, instances: {"i-02bf10b045dcea105": TaggedSetup { name: "my machine", s
etup: Setup { region: UsEast1, availability_zone: Any, instance_type: "t3.small", ami: "ami-085925f297f89fce1", username: "ubuntu" }, ip_info: Some(IpInfo { public_dns: "ec2-54-234-116-36.compute-1.amazonaws.com",
 public_ip: "54.234.116.36", private_ip: "172.31.3.193" }) }} }}:security_group{id=sg-0cf3db4d6b3582264}: tsunami::providers::aws: cleaned up temporary security group
test providers::aws::test::make_machine_and_ssh_setupfn ... ok
```