### PR TITLE
Improve spot requests cancellation upon timeout

### DIFF
--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -970,7 +970,7 @@ impl RegionLauncher {
         &mut self,
         max_wait: Option<time::Duration>,
     ) -> Result<(), Report> {
-        tracing::info!("waiting for {} instances to spawn", self.region.name());
+        tracing::info!("waiting for instances to spawn");
 
         let start = time::Instant::now();
 
@@ -1217,7 +1217,7 @@ impl RegionLauncher {
 
         // terminate instances
         if !self.instances.is_empty() {
-            tracing::info!("terminating {} instances", self.region.name());
+            tracing::info!("terminating instances");
             let instance_ids = self.instances.keys().cloned().collect();
             self.instances.clear();
             // Why is `?` here ok? either:
@@ -1322,10 +1322,7 @@ impl RegionLauncher {
 
     #[instrument(level = "debug")]
     async fn cancel_spot_instance_requests(&self) -> Result<(), Report> {
-        tracing::warn!(
-            "wait time exceeded for {} -- cancelling run",
-            self.region.name()
-        );
+        tracing::warn!("wait time exceeded for -- cancelling run");
         let request_ids = self.spot_requests.keys().cloned().collect();
         let mut cancel = rusoto_ec2::CancelSpotInstanceRequestsRequest::default();
         cancel.spot_instance_request_ids = request_ids;

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -1237,9 +1237,9 @@ impl RegionLauncher {
                 // clean up security groups and keys
                 let start = tokio::time::Instant::now();
                 loop {
-                    if start.elapsed() > tokio::time::Duration::from_secs(2 * 60) {
+                    if start.elapsed() > tokio::time::Duration::from_secs(5 * 60) {
                         Err(Report::msg(
-                            "failed to clean up temporary security group after 120 seconds.",
+                            "failed to clean up temporary security group after 5 minutes.",
                         ))?;
                         unreachable!();
                     }
@@ -1293,6 +1293,9 @@ impl RegionLauncher {
                 let msg = e.to_string();
                 if msg.contains("The spot instance request ID") && msg.contains("does not exist") {
                     tracing::trace!("spot instance requests not yet ready");
+
+                    // let's not hammer the API
+                    tokio::time::delay_for(time::Duration::from_secs(1)).await;
                     continue;
                 } else {
                     res.wrap_err("failed to describe spot instances")?;

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -970,7 +970,7 @@ impl RegionLauncher {
         &mut self,
         max_wait: Option<time::Duration>,
     ) -> Result<(), Report> {
-        tracing::info!("waiting for instances to spawn");
+        tracing::info!("waiting for {} instances to spawn", self.region.name());
 
         let start = time::Instant::now();
         let request_ids = self.spot_requests.keys().cloned().collect();
@@ -1219,7 +1219,7 @@ impl RegionLauncher {
 
         // terminate instances
         if !self.instances.is_empty() {
-            tracing::info!("terminating instances");
+            tracing::info!("terminating {} instances", self.region.name());
             let instance_ids = self.instances.keys().cloned().collect();
             self.instances.clear();
             self.terminate_instances(instance_ids).await?;
@@ -1320,7 +1320,10 @@ impl RegionLauncher {
 
     #[instrument(level = "debug")]
     async fn cancel_spot_instance_requests(&self, request_ids: &Vec<String>) -> Result<(), Report> {
-        tracing::warn!("wait time exceeded -- cancelling run");
+        tracing::warn!(
+            "wait time exceeded for {} -- cancelling run",
+            self.region.name()
+        );
         let mut cancel = rusoto_ec2::CancelSpotInstanceRequestsRequest::default();
         cancel.spot_instance_request_ids = request_ids.clone();
         self.client

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -1002,6 +1002,9 @@ impl RegionLauncher {
                 break;
             }
 
+            // let's not hammer the API
+            tokio::time::delay_for(time::Duration::from_secs(1)).await;
+
             if let Some(wait_limit) = max_wait {
                 if start.elapsed() <= wait_limit {
                     continue;
@@ -1009,9 +1012,6 @@ impl RegionLauncher {
                 self.cancel_spot_instance_requests(&request_ids).await?;
                 eyre::bail!("wait limit reached");
             }
-
-            // let's not hammer the API
-            tokio::time::delay_for(time::Duration::from_secs(1)).await;
         }
 
         Ok(())
@@ -1096,6 +1096,9 @@ impl RegionLauncher {
                 }
             }
 
+            // let's not hammer the API
+            tokio::time::delay_for(time::Duration::from_secs(1)).await;
+
             if let Some(wait_limit) = max_wait {
                 if start.elapsed() <= wait_limit {
                     continue;
@@ -1104,9 +1107,6 @@ impl RegionLauncher {
                 self.cancel_spot_instance_requests(&request_ids).await?;
                 eyre::bail!("wait limit reached");
             }
-
-            // let's not hammer the API
-            tokio::time::delay_for(time::Duration::from_secs(1)).await;
         }
 
         futures_util::future::join_all(self.instances.iter().map(

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -1007,6 +1007,7 @@ impl RegionLauncher {
                     continue;
                 }
                 self.cancel_spot_instance_requests(&request_ids).await?;
+                eyre::bail!("wait limit reached");
             }
 
             // let's not hammer the API
@@ -1101,6 +1102,7 @@ impl RegionLauncher {
                 }
                 let request_ids = self.spot_requests.keys().cloned().collect();
                 self.cancel_spot_instance_requests(&request_ids).await?;
+                eyre::bail!("wait limit reached");
             }
 
             // let's not hammer the API
@@ -1351,13 +1353,12 @@ impl RegionLauncher {
                     .collect();
                 self.terminate_instances(instance_ids).await?;
                 break;
-            } else {
-                // let's not hammer the API
-                tokio::time::delay_for(time::Duration::from_secs(1)).await;
             }
-        }
 
-        eyre::bail!("wait limit reached");
+            // let's not hammer the API
+            tokio::time::delay_for(time::Duration::from_secs(1)).await;
+        }
+        Ok(())
     }
 
     #[instrument(level = "debug")]

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -995,7 +995,7 @@ impl RegionLauncher {
                     .map(|(request_id, state, instance_id)| {
                         assert_eq!(state, "active");
                         let instance_id = instance_id.unwrap();
-                        let setup = self.spot_requests.get(&request_id).cloned().unwrap();
+                        let setup = self.spot_requests[&request_id].clone();
                         (instance_id, setup)
                     })
                     .collect();
@@ -1279,7 +1279,7 @@ impl RegionLauncher {
     #[instrument(level = "debug")]
     async fn describe_spot_instance_requests(
         &self,
-        request_ids: &Vec<String>,
+        request_ids: &[String],
     ) -> Result<Vec<(String, String, Option<String>)>, Report> {
         let client = self.client.as_ref().unwrap();
         loop {


### PR DESCRIPTION
This PR tries to make sure that cancellation of spot requests always happens when the `max_wait` timeout (passed to `spawn`) triggers. After cancellation, instances are terminated.

Most of the work was moving existing to code to new functions `describe_spot_instance_requests`, `cancel_spot_instance_requests` and `terminate_instances`,  so that these could be called in multiple places.

The "only change" was replacing the `remove` in `self.outstanding_spot_request_ids.remove(id).unwrap()` with a `get`. From what I could understand, it's possible to have more than one spot instance associated with the same spot instance request `id`, in which case the second `remove` would panic. Please let me know if this doesn't make sense. (I've also renamed `outstanding_spot_request_ids` to reflect this change.)

I've tested this a few times with different timeouts to make sure that cancellation is triggered in both `wait_for_spot_instance_requests` (e.g. 1s timeout) and `wait_for_instances` (e.g. 5s timeout).

(I've also made some cosmetic changes while I was getting familiar with the code; I'll revert these, if needed.)