### PR TITLE
WIP: Make private key file not temporary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 default = ["aws", "azure", "baremetal"]
-aws = ["rusoto_core", "rusoto_ec2", "futures-util", "tempfile", "ubuntu-ami"]
+aws = ["rusoto_core", "rusoto_ec2", "futures-util", "ubuntu-ami"]
 azure = ["serde", "serde_json", "futures-util", "tokio", "tokio/process"]
 baremetal = []
 args = ["structopt"]
@@ -35,7 +35,6 @@ tracing-futures = "0.2"
 rusoto_core = { version = "0.44.0", optional = true }
 rusoto_ec2 = {version = "0.44.0", optional = true }
 futures-util = { version = "0.3.4", optional = true }
-tempfile = { version = "3.0.0", optional = true }
 tokio = { version = "0.2.0", features = [ "time" ], optional = true }
 serde_json = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true}


### PR DESCRIPTION
For debugging reasons, sometimes it may be useful to ssh into the spawned spot instances. Currently, I believe this is not possible/easy. I was thinking of storing the private key in the current directory and name it something like `region_name.key`. Could something like this work?