### PR TITLE
Make region spans info

### DIFF
--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -393,7 +393,7 @@ where
             } = self;
 
             if !regions.contains_key(&l.region) {
-                let region_span = tracing::debug_span!("new_region", name = %l.region, az = %l.machines[0].1.availability_zone);
+                let region_span = tracing::debug_span!("new_region", region = %l.region, az = %l.machines[0].1.availability_zone);
                 let awsregion = RegionLauncher::new(
                     // region name and availability_zone spec are guaranteed to be the same because
                     // they are included in the region specifier.
@@ -407,7 +407,7 @@ where
                 regions.insert(l.region.clone(), awsregion);
             }
 
-            let region_span = tracing::debug_span!("region", name = %l.region);
+            let region_span = tracing::info_span!("region", region = %l.region);
             regions
                 .get_mut(&l.region)
                 .unwrap()
@@ -491,7 +491,7 @@ where
                     |(region_name, machines)| {
                         // unwrap ok because everything is a have now
                         let mut region_launcher = self.regions.remove(&region_name).unwrap();
-                        let region_span = tracing::debug_span!("region", region = %region_name);
+                        let region_span = tracing::info_span!("region", region = %region_name);
                         async move {
                             if let Err(e) = region_launcher
                                 .launch(max_instance_duration_hours, max_wait, machines)
@@ -556,7 +556,7 @@ where
 
                 let res =
                     futures_util::future::join_all(self.regions.drain().map(|(region, mut rl)| {
-                        let region_span = tracing::debug_span!("region", %region);
+                        let region_span = tracing::debug_span!("region", region = %region);
                         async move { rl.terminate_all().await }.instrument(region_span)
                     }))
                     .await;


### PR DESCRIPTION
I was trying to come up with a simple reproducer for [what looked like a bug in tracing](https://github.com/jonhoo/tsunami/pull/35#discussion_r435332408) but it turns out that my report was wrong. The reason why the region was not showing up in `tracing:info!` was the fact that there are two debug spans of interest, one in `launch` and another in `spawn`, and I made only one info while calling the other one 🤦. This PR makes both info.

With `tracing_subscriber::fmt::init();` and `RUST_LOG=info cargo run` the logs are a bit more verbose.

Now:
```
Jun 08 10:42:32.899  INFO tsunami::providers::aws: spinning up tsunami
Jun 08 10:42:36.413  INFO region{region=us-east-1}: tsunami::providers::aws: launching spot requests
Jun 08 10:42:36.413  INFO region{region=ap-south-1}: tsunami::providers::aws: launching spot requests
Jun 08 10:42:37.087  INFO region{region=ap-south-1}: tsunami::providers::aws: waiting for instances to spawn
Jun 08 10:42:37.174  INFO region{region=us-east-1}: tsunami::providers::aws: waiting for instances to spawn
Jun 08 10:43:36.570  INFO region{region=us-east-1}:setup_machine{nickname="east" pub_ip="3.80.141.180" username="ubuntu"}: tsunami::providers: instance ready
Jun 08 10:43:46.196  INFO region{region=ap-south-1}:setup_machine{nickname="india" pub_ip="52.66.199.50" username="ubuntu"}: tsunami::providers: instance ready
Jun 08 10:44:06.882  INFO tsunami::providers::aws: terminating instances
Jun 08 10:44:06.888  INFO tsunami::providers::aws: terminating instances
```

Before:
```
Jun 08 10:47:05.181  INFO tsunami::providers::aws: spinning up tsunami
Jun 08 10:47:08.382  INFO tsunami::providers::aws: launching spot requests
Jun 08 10:47:08.382  INFO tsunami::providers::aws: launching spot requests
Jun 08 10:47:09.159  INFO tsunami::providers::aws: waiting for instances to spawn
Jun 08 10:47:09.224  INFO tsunami::providers::aws: waiting for instances to spawn
Jun 08 10:47:50.765  INFO setup_machine{nickname="india" pub_ip="3.6.89.116" username="ubuntu"}: tsunami::providers: instance ready
Jun 08 10:48:06.714  INFO setup_machine{nickname="east" pub_ip="3.91.27.241" username="ubuntu"}: tsunami::providers: instance ready
Jun 08 10:48:27.154  INFO tsunami::providers::aws: terminating instances
Jun 08 10:48:27.186  INFO tsunami::providers::aws: terminating instances
```

BTW, when there's a timeout, I'm getting a warning that seems to come from [color-eyre](https://github.com/yaahc/color-eyre/blob/fff76b1424616402d64b881da1bf198eedae2b1b/src/lib.rs#L498):

```
Jun 08 11:09:34.026  INFO tsunami::providers::aws: spinning up tsunami
Jun 08 11:09:36.970  INFO region{region=us-east-1}: tsunami::providers::aws: launching spot requests
Jun 08 11:09:36.970  INFO region{region=ap-south-1}: tsunami::providers::aws: launching spot requests
Jun 08 11:09:37.633  INFO region{region=ap-south-1}: tsunami::providers::aws: waiting for instances to spawn
Jun 08 11:09:37.815  INFO region{region=us-east-1}: tsunami::providers::aws: waiting for instances to spawn
Jun 08 11:10:04.464  WARN region{region=ap-south-1}: tsunami::providers::aws: wait time exceeded for -- cancelling run
Jun 08 11:10:06.021  WARN region{region=us-east-1}: tsunami::providers::aws: wait time exceeded for -- cancelling run
Error:
   0: failed while waiting for instances to come up
   1: wait limit reached

Warning: SpanTrace capture is Unsupported.
Ensure that you've setup an error layer and the versions match
```

I'm not sure if it is related with this change, but I did a few runs in master and didn't get the warning:
```
Jun 08 10:52:37.598  INFO tsunami::providers::aws: spinning up tsunami
Jun 08 10:52:40.815  INFO tsunami::providers::aws: launching spot requests
Jun 08 10:52:40.815  INFO tsunami::providers::aws: launching spot requests
Jun 08 10:52:41.484  INFO tsunami::providers::aws: waiting for instances to spawn
Jun 08 10:52:41.643  INFO tsunami::providers::aws: waiting for instances to spawn
Jun 08 10:52:50.052  WARN tsunami::providers::aws: wait time exceeded for -- cancelling run
Jun 08 10:52:55.266  WARN tsunami::providers::aws: wait time exceeded for -- cancelling run
Error:
   0: failed while waiting for instances to come up
   1: wait limit reached
```
