### PR TITLE
Set Machine's public_dns in AWS and private_ip in Azure

### DIFF
--- a/examples/launch.rs
+++ b/examples/launch.rs
@@ -1,4 +1,4 @@
-use color_eyre::Report;
+use color_eyre::{eyre, Report};
 use structopt::StructOpt;
 use tsunami::Tsunami;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,14 +252,10 @@ impl<'t> MachineDescriptor<'t> {
         tracing::trace!("connected");
 
         let public_ip = self.public_ip;
-        // if not defined, set public dns to be the public ip
-        let public_dns = self
-            .public_dns
-            .map(String::from)
-            .unwrap_or_else(|| public_ip.clone());
         Ok(Machine {
             nickname: self.nickname,
-            public_dns,
+            // if not defined, set public dns to be the public ip
+            public_dns: self.public_dns.unwrap_or_else(|| public_ip.clone()),
             public_ip,
             private_ip: self.private_ip,
             _tsunami: self._tsunami,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,9 +186,9 @@ pub mod providers;
 #[derive(Debug)]
 struct MachineDescriptor<'tsunami> {
     pub(crate) nickname: String,
+    pub(crate) public_dns: Option<String>,
     pub(crate) public_ip: String,
     pub(crate) private_ip: Option<String>,
-    pub(crate) public_dns: String,
 
     // tie the lifetime of the machine to the Tsunami.
     _tsunami: std::marker::PhantomData<&'tsunami ()>,
@@ -203,15 +203,15 @@ pub struct Machine<'tsunami> {
     ///
     /// Corresponds to the name set in [`TsunamiBuilder::add`].
     pub nickname: String,
-    /// The public IP address of the machine.
-    pub public_ip: String,
-    /// The private IP address of the machine, if available.
-    pub private_ip: Option<String>,
     /// The public DNS name of the machine.
     ///
     /// If the instance doesn't have a DNS name, this field will be
     /// equivalent to `public_ip`.
     pub public_dns: String,
+    /// The public IP address of the machine.
+    pub public_ip: String,
+    /// The private IP address of the machine, if available.
+    pub private_ip: Option<String>,
 
     /// An established SSH session to this host.
     pub ssh: openssh::Session,
@@ -253,9 +253,13 @@ impl<'t> MachineDescriptor<'t> {
 
         Ok(Machine {
             nickname: self.nickname,
+            // if not defined, set public dns to be the public ip
+            public_dns: self
+                .public_dns
+                .map(String::from)
+                .unwrap_or(self.public_ip.to_string()),
             public_ip: self.public_ip,
             private_ip: self.private_ip,
-            public_dns: self.public_dns,
             _tsunami: self._tsunami,
             ssh: sess,
             username: username.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,14 +251,16 @@ impl<'t> MachineDescriptor<'t> {
         let sess = sess.connect(&self.public_ip).await?;
         tracing::trace!("connected");
 
+        let public_ip = self.public_ip;
+        // if not defined, set public dns to be the public ip
+        let public_dns = self
+            .public_dns
+            .map(String::from)
+            .unwrap_or_else(|| public_ip.clone());
         Ok(Machine {
             nickname: self.nickname,
-            // if not defined, set public dns to be the public ip
-            public_dns: self
-                .public_dns
-                .map(String::from)
-                .unwrap_or(self.public_ip.to_string()),
-            public_ip: self.public_ip,
+            public_dns,
+            public_ip,
             private_ip: self.private_ip,
             _tsunami: self._tsunami,
             ssh: sess,

--- a/src/providers/azure.rs
+++ b/src/providers/azure.rs
@@ -375,6 +375,7 @@ impl super::Launcher for RegionLauncher {
                                     &nickname,
                                     None,
                                     &ipinfo.public_ip,
+                                    Some(&ipinfo.private_ip),
                                     &username,
                                     max_wait,
                                     None,
@@ -424,7 +425,7 @@ impl super::Launcher for RegionLauncher {
                     } = desc;
                     let m = crate::MachineDescriptor {
                         nickname: name.clone(),
-                        public_dns: public_ip.clone(),
+                        public_dns: None,
                         public_ip: public_ip.clone(),
                         private_ip: Some(private_ip.clone()),
                         _tsunami: Default::default(),

--- a/src/providers/baremetal.rs
+++ b/src/providers/baremetal.rs
@@ -134,7 +134,7 @@ async fn try_addrs(
 
             let m = crate::MachineDescriptor {
                 nickname: Default::default(),
-                public_dns: addr.ip().to_string(),
+                public_dns: None,
                 public_ip: addr.ip().to_string(),
                 private_ip: None,
                 _tsunami: Default::default(),
@@ -220,7 +220,7 @@ impl super::Launcher for Machine {
             {
                 let m = crate::MachineDescriptor {
                     nickname: Default::default(),
-                    public_dns: addr.ip().to_string(),
+                    public_dns: None,
                     public_ip: addr.ip().to_string(),
                     private_ip: None,
                     _tsunami: Default::default(),
@@ -252,7 +252,7 @@ impl super::Launcher for Machine {
             let addr = self.addr.ok_or_else(|| eyre!("Address uninitialized"))?;
             let m = crate::MachineDescriptor {
                 nickname: self.name.clone(),
-                public_dns: addr.ip().to_string(),
+                public_dns: None,
                 public_ip: addr.ip().to_string(),
                 private_ip: None,
                 _tsunami: Default::default(),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -170,8 +170,9 @@ fn rand_name_sep(prefix: &str, sep: impl Into<Sep>) -> String {
 #[instrument(skip(max_wait, private_key, f))]
 async fn setup_machine(
     nickname: &str,
-    priv_ip: Option<&str>,
-    pub_ip: &str,
+    public_dns: Option<&str>,
+    public_ip: &str,
+    private_ip: Option<&str>,
     username: &str,
     max_wait: Option<std::time::Duration>,
     private_key: Option<&std::path::Path>,
@@ -183,9 +184,9 @@ async fn setup_machine(
 ) -> Result<(), Report> {
     let m = crate::MachineDescriptor {
         nickname: Default::default(),
-        public_dns: pub_ip.to_string(),
-        public_ip: pub_ip.to_string(),
-        private_ip: priv_ip.map(String::from),
+        public_dns: public_dns.map(String::from),
+        public_ip: public_ip.to_string(),
+        private_ip: private_ip.map(String::from),
         _tsunami: Default::default(),
     };
 


### PR DESCRIPTION
This PR sets `Machine.public_dns` in AWS and `Machine.private_ip` in Azure (information we had, that was just not being recorded).

While doing this change, the logic of "setting public_dns equal to public_ip if there's no public_dns" was moved up to `connect_ssh`. Now this rule lives in this single place.

(For some sanity, I've also reordered some things to make sure that the following order is maintained: `public_dns`, `public_ip`, and `private_ip`)