### PR TITLE
TrySpot Mode

### DIFF
--- a/examples/launch.rs
+++ b/examples/launch.rs
@@ -41,6 +41,8 @@ fn wait_for_continue() {
 #[tokio::main]
 async fn main() -> Result<(), Report> {
     let opt = Opt::from_args();
+    tracing_subscriber::fmt::init();
+    color_eyre::install()?;
 
     match opt.provider {
         Providers::AWS => {

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -144,6 +144,19 @@ impl LaunchMode {
         Self::DefinedDuration { hours }
     }
 
+    /// Try to launch using AWS [defined
+    /// duration](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#fixed-duration-spot-instances)
+    /// spot instances, and fall back to OnDemand instances otherwise.
+    ///
+    /// The lifetime of such instances must be declared in advance (1-6 hours).
+    /// This method thus clamps `hours` to be between 1 and 6.
+    pub fn try_duration_spot(hours: usize) -> Self {
+        match Self::duration_spot(hours) {
+            Self::DefinedDuration { hours } => Self::TrySpot { hours },
+            _ => unreachable!(),
+        }
+    }
+
     /// Launch using regular AWS on-demand instances.
     pub fn on_demand() -> Self {
         Self::OnDemand

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -755,6 +755,9 @@ impl RegionLauncher {
                 hours: max_instance_duration_hours,
             } => {
                 let machines = machines.clone();
+
+                // leave this to short-circuit: we only want to fall back to OnDemand if there is
+                // no spot capacity, not if we can't make the request in the first place.
                 self.make_spot_instance_requests(
                     max_instance_duration_hours * 60, // 60 mins/hr
                     machines,
@@ -776,9 +779,9 @@ impl RegionLauncher {
                     if let LaunchMode::TrySpot { .. } = mode {
                         tracing::debug!(err = ?e, "re-trying with OnDemand instace");
                         do_ondemand = true;
+                    } else {
+                        Err(e)?;
                     }
-
-                    Err(e)?;
                 }
 
                 if let Some(ref mut d) = max_wait {


### PR DESCRIPTION
Add the ability to try for spot instances, but fail back to on-demand instances if there was no spot capacity.