### PR TITLE
Fix TrySpot launch mode

### DIFF
--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -795,10 +795,10 @@ impl RegionLauncher {
                     } else {
                         return Err(e);
                     }
-                }
-
-                if let Some(ref mut d) = max_wait {
-                    *d -= time::Instant::now().duration_since(start);
+                } else {
+                    if let Some(ref mut d) = max_wait {
+                        *d -= time::Instant::now().duration_since(start);
+                    }
                 }
             }
             LaunchMode::OnDemand => {


### PR DESCRIPTION
If the timer expired, we shouldn't be trying to subtract the elapsed time from it.